### PR TITLE
Add rdo-vms role to create a cluster of vms on RDO

### DIFF
--- a/ansible/create-openshift-311-vms.yml
+++ b/ansible/create-openshift-311-vms.yml
@@ -1,0 +1,27 @@
+---
+- hosts: rdo-vm-manager
+  roles:
+    - role: rdo-networks
+    - role: rdo-vms
+  vars:
+    vms: 
+      master:
+        flavor: 'm1.xlarge'
+        net: 'private_k8s_net'
+        groups: ['master', 'openshift']
+      worker1:
+        flavor: 'm1.large'
+        net: 'private_k8s_net'
+        groups: ['compute', 'openshift']
+      worker2:
+        flavor: 'm1.large'
+        net: 'private_k8s_net'
+        groups: ['compute', 'openshift']    
+    add_to_runtime_inventory: True
+    create_inventory:
+      template: openshift-ansible-3.11-inventory.j2
+      dest: openshift-3.11-inventory
+      
+  tasks:
+    - debug: var=hosts
+      tags: always

--- a/ansible/roles/rdo-vms/defaults/main.yml
+++ b/ansible/roles/rdo-vms/defaults/main.yml
@@ -1,0 +1,2 @@
+---
+add_to_runtime_inventory: False

--- a/ansible/roles/rdo-vms/tasks/create-rdo-vms.yml
+++ b/ansible/roles/rdo-vms/tasks/create-rdo-vms.yml
@@ -1,0 +1,46 @@
+---
+- name: Create VM group on RDO cloud
+  os_server:
+    cloud: rdocloud
+    state: present
+    name: "{{ item.key }}"
+    image: "{{ item.value.image | default('CentOS-7-x86_64-GenericCloud-1804_02') }}"
+    key_name: "{{ ssh_key_name }}"
+    nics:
+      - net-name: "{{ item.value.net }}"
+    auto_ip: yes
+    security_groups: "{{ item.value.security_groups | default (['ssh_icmp']) }}"
+    flavor: "{{ item.value.flavor }}"
+  with_dict: "{{ vms }}"
+  register: os_hosts
+
+- name: Create host list out of os_server output
+  set_fact:
+    hosts: >
+      {{ hosts|default([]) +
+        [ {'host': item.item.key,
+           'groups': item.item.value.groups,
+           'ip': item.server.public_v4} ]
+      }}
+  with_items: "{{ os_hosts.results }}"
+  loop_control:
+    label: "{{ item.item.key }} {{ item.item.value.groups }}"
+
+- name: Create openshift-ansible inventory
+  template:
+    src: "{{ create_inventory.template }}"
+    dest: "{{ create_inventory.dest }}"
+  when: create_inventory is defined
+
+- name: Add hosts to the runtime inventory
+  add_host:
+    name: '{{ item.host }}'
+    groups: '{{ item.groups }}'
+    ansible_host: "{{ item.ip }}"
+    ansible_user: centos
+    ansible_become: true
+    host_key_checking: false
+  with_items: "{{ hosts }}"
+  changed_when: False
+  when: add_to_runtime_inventory == true
+

--- a/ansible/roles/rdo-vms/tasks/delete-rdo-vms.yml
+++ b/ansible/roles/rdo-vms/tasks/delete-rdo-vms.yml
@@ -1,0 +1,17 @@
+---
+- name: Remove VM group on RDO cloud
+  os_server:
+    state: absent
+    name: "{{ item.key }}"
+    cloud: rdocloud
+  with_dict: "{{ vms }}"
+
+- name: Remove openshift-ansible inventory
+  file:
+    state: absent
+    path: "{{ create_inventory.dest }}"
+  when: create_inventory is defined
+
+- name: Remove the hosts output
+  set_fact:
+    hosts: []

--- a/ansible/roles/rdo-vms/tasks/main.yml
+++ b/ansible/roles/rdo-vms/tasks/main.yml
@@ -1,0 +1,5 @@
+---
+- import_tasks: create-rdo-vms.yml
+  tags: [create]
+- import_tasks: delete-rdo-vms.yml
+  tags: [delete]

--- a/ansible/templates/openshift-ansible-3.11-inventory.j2
+++ b/ansible/templates/openshift-ansible-3.11-inventory.j2
@@ -1,0 +1,49 @@
+[masters]
+{% for host in hosts if 'master' in host.groups %}
+{{ host.host }} ansible_ssh_host={{ host.ip }}
+{% endfor %}
+
+
+#[lb]
+#{% for host in hosts if 'master' in host.groups %}
+#{{ host.host }} ansible_ssh_host={{ host.ip }}
+#{% endfor %}
+
+[etcd]
+{% for host in hosts if 'master' in host.groups %}
+{{ host.host }} ansible_ssh_host={{ host.ip }}
+{% endfor %}
+
+[nodes]
+{% for host in hosts if 'master' in host.groups %}
+{{ host.host }} ansible_ssh_host={{ host.ip }} openshift_node_group_name="node-config-master"
+{% endfor %}
+
+{% for host in hosts if 'compute' in host.groups %}
+{{ host.host }} ansible_ssh_host={{ host.ip }} openshift_node_group_name="node-config-compute"
+{% endfor %}
+
+[OSEv3:children]
+masters
+nodes
+etcd
+#lb
+
+[OSEv3:vars]
+ansible_user=centos
+ansible_become=yes
+openshift_deployment_type=origin
+openshift_release="3.11"
+openshift_master_default_subdomain=openshift.{{ hosts[0].ip }}.xip.io
+openshift_enable_excluders=false
+openshift_master_public_api_url=https://{{ hosts[0].ip }}.xip.io:8443
+openshift_master_public_console_url=https://{{ hosts[0].ip }}.xip.io:8443
+openshift_public_hostname={{ hosts[0].ip }}.xip.io
+openshift_master_default_subdomain=apps.{{ hosts[0].ip }}.xip.io
+openshift_public_ip={{ hosts[0].ip }}
+openshift_web_console_install=false
+openshift_cluster_monitoring_operator_install=false
+openshift_enable_service_catalog=false
+openshift_web_console_install=false
+openshift_console_install=false
+debug_level=2


### PR DESCRIPTION
The role can be invoked from any playbook to spawn a set
of VMs, add them to the dynamic inventory, or generate
an ansible inventory file.