### PR TITLE
Revert "User specify network name and CIDR"

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,13 +76,13 @@ $ vim ansible/clouds.yml
 ## Deploying a 3.11 openshift cluster
 
 ```bash
-./run.sh deploy openshift-cluster -v 3.11 -n c0 -k mbp-ajo --cluster-cidr 192.168.0.0/24
+./run.sh deploy openshift-cluster -v 3.11 -n c0 -k mbp-ajo
 ```
 
 ## Deploying a second 3.11 openshift cluster
 
 ```bash
-./run.sh deploy openshift-cluster -v 3.11 -n c1 --pod-cidr 10.132.0.0/14 --service-cidr 172.31.0.0/16 --cluster-cidr 192.168.0.0/24
+./run.sh deploy openshift-cluster -v 3.11 -n c1 --pod-cidr 10.132.0.0/14 --service-cidr 172.31.0.0/16
 ```
 
 ## Deploying a 4.00 openshift cluster
@@ -158,9 +158,6 @@ Options:
 
   -X, --service-cidr <cidr> (default is 172.30.0.0/16, avoid 172.17.0.0/16 docker0 range)
                    This is the desidred Service CIDR for the cluster
-
-  -C, --cluster-cidr <cidr> (default is 10.0.0.0/24)
-                   This is the desired cluster CIDR
 
 Common options:
 

--- a/ansible/os-cluster-3.yml
+++ b/ansible/os-cluster-3.yml
@@ -28,9 +28,6 @@
     create_inventory:
       template: openshift-ansible-3.11-inventory.j2
       dest: "inventory/{{ cluster_name }}-openshift-3.11-inventory"
-    networks:
-      "{{ cluster_name }}":
-        cidr: "{{ cluster_cidr }}"
 
 - name: Prepare hosts of cluster for openshift-ansible
   hosts: "{{ cluster_name }}"

--- a/ansible/roles/rdo-networks/defaults/main.yml
+++ b/ansible/roles/rdo-networks/defaults/main.yml
@@ -1,0 +1,4 @@
+---
+networks:
+  private_k8s:
+    cidr: 10.0.0.0/24

--- a/run.sh
+++ b/run.sh
@@ -241,7 +241,6 @@ OPT_SSH_KEY=$(cat $DIR/ansible/inventory/.ssh_key_name 2>/dev/null)
 OPT_POD_CIDR=10.128.0.0/14
 OPT_SERVICE_CIDR=172.30.0.0/16
 OPT_PRIVATE_SSH_KEY=$HOME/.ssh/id_rsa
-OPT_CLUSTER_CIDR=10.0.0.0/24
 
 while [ "x$1" != "x" ]; do
     case "$1" in
@@ -318,11 +317,6 @@ while [ "x$1" != "x" ]; do
 
         --service-cidr|-X)
             OPT_SERVICE_CIDR=$2
-            shift
-            ;;
-
-        --cluster-cidr|-C)
-            OPT_CLUSTER_CIDR=$2
             shift
             ;;
 
@@ -457,7 +451,6 @@ deploy_openshift_cluster() {
                          -e ssh_key_name=$OPT_SSH_KEY \
                          -e ssh_private_key=$OPT_SSH_PRIVATE_KEY \
                          -e cluster_name=$OPT_NAME \
-                         -e cluster_cidr=$OPT_CLUSTER_CIDR \
                          ${OPT_SKIP_TAGS[@]} \
                          $DIR/ansible/os-cluster-4.yml \
                          -i $DIR/ansible/inventory \
@@ -477,7 +470,6 @@ deploy_openshift_cluster() {
                          -e ssh_key_name=$OPT_SSH_KEY \
                          -e ssh_private_key=$OPT_SSH_PRIVATE_KEY \
                          -e cluster_name=$OPT_NAME \
-                         -e cluster_cidr=$OPT_CLUSTER_CIDR \
                          -e pod_cidr=$OPT_POD_CIDR \
                          -e service_cidr=$OPT_SERVICE_CIDR \
                          -i $DIR/ansible/inventory \


### PR DESCRIPTION
Reverts dfarrell07/skynet-tools#11

As discussed in slack:
   
 * it's not really necessary for deploying several clusters (could be useful for testing nat traversal though)
 * it breaks the toolbox deployment
 * makes working (from toolbox to deployment) harder.

Alternatively I can create a patch to fix the toolbox, but I prefer less complexity unless we really really need it :)