### PR TITLE
Tools for toolbox

### DIFF
--- a/ansible/roles/toolbox/tasks/install-basics.yml
+++ b/ansible/roles/toolbox/tasks/install-basics.yml
@@ -30,3 +30,10 @@
     name: [git, vim, tree, tmux]
   become: yes
 
+- name: Install github hub tool
+  shell: |
+     cd /tmp
+     curl -L https://github.com/github/hub/releases/download/v2.12.0/hub-linux-amd64-2.12.0.tgz | tar xfz -
+     cd hub-linux-amd64-2.12.0
+     ./install
+  become: yes

--- a/ansible/roles/toolbox/tasks/install-k8s-tools.yml
+++ b/ansible/roles/toolbox/tasks/install-k8s-tools.yml
@@ -1,0 +1,30 @@
+---
+- name: Install docker
+  yum: name=docker state=present
+  become: yes
+
+- name: Enable docker service
+  service: name=docker state=started enabled=yes
+  become: yes
+
+- name: Install kubectl
+  shell: |
+    cd /usr/local/bin
+    curl -LO https://storage.googleapis.com/kubernetes-release/release/$(curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt)/bin/linux/amd64/kubectl
+    chmod a+x kubectl
+  become: yes
+
+- name: Install kubefed tool
+  shell: |
+    cd /tmp
+    KUBEFED_VERSION=0.1.0-rc2
+    ARCH=amd64
+    curl -LO "https://github.com/kubernetes-sigs/kubefed/releases/download/v${KUBEFED_VERSION}/kubefedctl-${KUBEFED_VERSION}-linux-${ARCH}.tgz"
+    tar -xzf kubefedctl-${KUBEFED_VERSION}-linux-${ARCH}.tgz
+    cp kubefedctl /usr/bin/
+    chmod a+x /usr/bin/kubefedctl
+  become: yes
+
+- name: Disable selinux which won't work for kind
+  selinux: state=disabled
+  become: yes

--- a/ansible/roles/toolbox/tasks/main.yml
+++ b/ansible/roles/toolbox/tasks/main.yml
@@ -1,3 +1,6 @@
 ---
 - import_tasks: install-basics.yml
   tags: [toolbox]
+
+- import_tasks: install-k8s-tools.yml
+  tags: [toolbox]


### PR DESCRIPTION
The next commits add tools I was missing to build and test submariner on the toolbox
using make e2e, etc...

   * docker (selinux disabled for kind to be happy)
   * kubectl
   * kubefedctl
  
Also adds:
   * github hub tool.